### PR TITLE
Add Validation State Change Events

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.1
+version=1.0.2

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,5 +1,13 @@
 apply plugin: 'com.android.library'
 
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    compile 'com.nineoldandroids:library:2.4.0'
+}
+
 android {
     compileSdkVersion 19
     buildToolsVersion "19.1.0"
@@ -16,10 +24,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
-}
-
-dependencies {
-    compile 'com.nineoldandroids:library:2.4.0'
 }
 
 // Generate pom, ivy.xml

--- a/library/src/androidTest/java/com/paymentkit/TestFieldHolder.java
+++ b/library/src/androidTest/java/com/paymentkit/TestFieldHolder.java
@@ -2,15 +2,24 @@ package com.paymentkit;
 
 import android.test.ActivityInstrumentationTestCase2;
 import android.test.UiThreadTest;
+import android.widget.EditText;
 
+import com.paymentkit.views.CVVEditText;
+import com.paymentkit.views.CardNumEditText;
 import com.paymentkit.views.CardNumHolder;
+import com.paymentkit.views.ExpirationEditText;
 import com.paymentkit.views.FieldHolder;
+import com.paymentkit.views.PostCodeEditText;
 
 public class TestFieldHolder extends ActivityInstrumentationTestCase2<FieldHolderTestActivity> {
 
     private FieldHolderTestActivity testActivity;
     private FieldHolder fieldHolder;
     private CardNumHolder cardNumHolder;
+    private CardNumEditText cardNumEdit;
+    private ExpirationEditText expEdit;
+    private CVVEditText cvvEdit;
+    private PostCodeEditText postCodeEdit;
 
     private static final String validMC   = "5555555555554444";
     private static final String invalidMC = "5555555555554044";
@@ -26,6 +35,10 @@ public class TestFieldHolder extends ActivityInstrumentationTestCase2<FieldHolde
         testActivity = getActivity();
         fieldHolder = (FieldHolder) testActivity.findViewById(com.paymentkit.test.R.id.field_holder);
         cardNumHolder = fieldHolder.getCardNumHolder();
+        cardNumEdit = cardNumHolder.getCardField();
+        expEdit = fieldHolder.getExpirationEditText();
+        cvvEdit = fieldHolder.getCVVEditText();
+        postCodeEdit = fieldHolder.getPostCodeEditText();
     }
 
     public void testPreconditions() {
@@ -36,12 +49,12 @@ public class TestFieldHolder extends ActivityInstrumentationTestCase2<FieldHolde
 
     @UiThreadTest
     public void testCardNumberEntry() {
-        cardNumHolder.getCardField().setText(invalidMC);
+        cardNumEdit.setText(invalidMC);
         assertFalse("Card number expected to be invalid " + invalidMC, cardNumHolder.isCardNumValid());
 
         // Note: We must change length of text before all text watching events get handled properly
-        cardNumHolder.getCardField().setText("");
-        cardNumHolder.getCardField().setText(validMC);
+        cardNumEdit.setText("");
+        cardNumEdit.setText(validMC);
         assertTrue("Card number expected to be valid " + validMC, cardNumHolder.isCardNumValid());
         assertTrue("Card expected to be Master Card", fieldHolder.getCardIcon().isCardType(CardType.MASTERCARD));
 
@@ -50,8 +63,139 @@ public class TestFieldHolder extends ActivityInstrumentationTestCase2<FieldHolde
         assertTrue("Last 4 digits expected to be "+last4, last4.equals(cardNumHolder.getLastFourDigits()));
     }
 
+    @UiThreadTest
+    public void testOnValidationEvent() {
+        final String validExpDate = "9/17";
+        final String validCVV = "123";
+        final String validPostCode = "90210";
+
+        ValidationListener listener = new ValidationListener();
+        fieldHolder.setOnValidationEventListener(listener);
+        fieldHolder.setRequirePostCode(true);
+
+        long lastEventTime = listener.getEventTime();
+        // Card Number
+        // Note: We must change length of text before all text watching events get handled properly
+        cardNumEdit.setText("");
+        assertEquals("Expected no validation event when clearing card number text", listener.getEventTime(), lastEventTime);
+        cardNumEdit.setText(validMC);
+        assertEquals("Expected no validation event when setting card number text", listener.getEventTime(), lastEventTime);
+        // Expiration
+        expEdit.setText(validExpDate);
+        assertEquals("Expected no validation event when setting expiration text", listener.getEventTime(), lastEventTime);
+        // CVV
+        cvvEdit.setText(validCVV);
+        assertEquals("Expected no validation event when setting CVV text", listener.getEventTime(), lastEventTime);
+        // Postal Code
+        postCodeEdit.setText(validPostCode);
+        assertFalse("Expected a validation event when setting post code text", listener.getEventTime() == lastEventTime);
+        int lastEventCount = listener.getCount();
+        assertTrue("Expected 1 validation event when finished setting all fields", lastEventCount == 1);
+        assertTrue("Expected card data to be valid", listener.isValid());
+
+        // Invalidate each individual field in turn and verify that 1 validation event is fired and
+        // it's that the data has become invalid
+        invalidateField(cardNumEdit, listener, "card number");
+        cardNumEdit.setText(validMC); // reset, make data set valid again
+        invalidateField(expEdit, listener, "exp date");
+        expEdit.setText(validExpDate); // reset, make data set valid again
+        invalidateField(cvvEdit, listener, "cvv");
+        cvvEdit.setText(validCVV); // reset, make data set valid again
+        invalidateField(postCodeEdit, listener, "post code");
+        postCodeEdit.setText(validPostCode);
+
+        // Invalidate 2 fields, then reset each value to valid testing that the 1 invalidation event
+        // then the 1 validation event happen properly -- and run it for every pair of fields
+        EditText[] fields = {cardNumEdit, expEdit, cvvEdit, postCodeEdit};
+        String[] validValues = {validMC, validExpDate, validCVV, validPostCode};
+        combinatorialInvalidate2Fields(fields, validValues, 0, listener);
+    }
+
+    /**
+     * Invalidate the data in the given EditText field and assert() that the appropriate events
+     * were fired on the ValidationListener.
+     *
+     * Assumptions:
+     * The card data set up is valid when this method is called.
+     */
+    private void invalidateField(EditText field, ValidationListener listener, String fieldDesc) {
+        // Edit field value, make data invalid
+        long lastEventTime = listener.getEventTime();
+        int lastEventCount = listener.getCount();
+        field.setText(field.getText().subSequence(0, field.length() - 2));
+        assertTrue("Expected validation event [time] when invalidating "+fieldDesc, listener.getEventTime() != lastEventTime);
+        assertEquals("Expected validation event [count] when invalidating "+fieldDesc, listener.getCount(), lastEventCount + 1);
+        assertFalse("Expected validation event [invalid] when invalidating "+fieldDesc, listener.isValid());
+    }
+
+    /**
+     * Run invalidate2Fields on all permutations of the given fields (taken 2 at a time).
+     * Note: If there are N fields then this will run N!/(N-2)! tests. Beware.
+     *
+     * @param fields All the fields that should be tested with invalidate2Fields()
+     * @param validValues Valid values for each field in {@code fields} _in order_
+     * @param startIndex The index into {@code fields} to start choosing fields to test
+     * @param listener The ValidationListener to use during the test
+     */
+    private void combinatorialInvalidate2Fields(EditText[] fields, String[] validValues, int startIndex, ValidationListener listener) {
+        int end = fields.length;
+        for (int i = startIndex+1; i < end; i++) {
+            invalidate2Fields(fields[startIndex], fields[i], validValues[startIndex], validValues[i], listener);
+            invalidate2Fields(fields[i], fields[startIndex], validValues[i], validValues[startIndex], listener);
+        }
+        if (startIndex < (fields.length-2))
+            combinatorialInvalidate2Fields(fields, validValues, startIndex + 1, listener);
+    }
+
+    /**
+     * Test that, starting from a valid data set, that 1) invalidating {@code fieldA} invalidates the
+     * data; 2) then invalidating {@code fieldB} does NOT fire invalidation events; 3) resetting
+     * {@code fieldA} to a valid value does NOT fire invalidation events; 4) resetting {@code fieldB}
+     * to a valid value DOES fire 1 validation event.
+     */
+    private void invalidate2Fields(EditText fieldA, EditText fieldB, String validValueA, String validValueB, ValidationListener listener) {
+        assertTrue(listener.isValid());
+        invalidateField(fieldA, listener, fieldA.toString()); // will fire 1 invalidation event
+        long lastEventTime = listener.getEventTime();
+        int lastEventCount = listener.getCount();
+        // Note: Can't call invalidateField() a second time because we expect that no events
+        // should be fired. So we invalidate the field manually.
+        fieldB.setText(fieldB.getText().subSequence(0, fieldB.length()-2));
+        fieldB.setText(validValueB);
+        assertEquals("Expected no validation event [time] when fixing 1st of 2 invalid fields "+fieldB,
+                listener.getEventTime(), lastEventTime);
+        assertEquals("Expected no validation event [count] when fixing 1st of 2 invalid fields "+fieldB,
+                listener.getCount(), lastEventCount);
+        assertFalse("Expected no validation event [invalid] when fixing 1st of 2 invalid fields "+fieldB,
+                listener.isValid());
+        fieldA.setText(validValueA);
+        assertTrue("Expected validation event [time] when fixing 2nd of 2 invalid fields "+fieldA,
+                listener.getEventTime() != lastEventTime);
+        assertEquals("Expected validation event [count] when fixing 2nd of 2 invalid fields "+fieldA,
+                listener.getCount(), lastEventCount+1);
+        assertTrue("Expected validation event [invalid] when fixing 2nd of 2 invalid fields "+fieldA,
+                listener.isValid());
+    }
+
     @Override
     protected void tearDown() throws Exception {
         super.tearDown();
+    }
+
+    private class ValidationListener implements FieldHolder.OnValidationEventListener {
+        boolean valid = false;
+        long eventTime = 0;
+        int count = 0;
+        @Override
+        public void onValidationEvent(boolean isValid) {
+            synchronized (this) {
+                eventTime = System.nanoTime();
+                valid = isValid;
+                count++;
+            }
+        }
+        public synchronized boolean isValid() { return valid; }
+        public synchronized long getEventTime() { return eventTime; }
+        public synchronized int getCount() { return count; }
     }
 }

--- a/library/src/main/java/com/paymentkit/views/CVVEditText.java
+++ b/library/src/main/java/com/paymentkit/views/CVVEditText.java
@@ -137,6 +137,7 @@ public class CVVEditText extends EditText {
 	private TextWatcher mTextWatcher = new TextWatcher() {
 		@Override
 		public void afterTextChanged(Editable s) {
+            mListener.onCVVEdit();
 			if (s.length() == cvvMaxLength) {
 				mListener.onCVVEntryComplete();
 			}

--- a/library/src/main/java/com/paymentkit/views/ExpirationEditText.java
+++ b/library/src/main/java/com/paymentkit/views/ExpirationEditText.java
@@ -76,6 +76,8 @@ public class ExpirationEditText extends EditText {
 
             validateAndFormatText(s);
 
+            mListener.onExpirationEdit();
+
             addTextChangedListener(this);
 		}
 
@@ -211,7 +213,7 @@ public class ExpirationEditText extends EditText {
     private OnFocusChangeListener mFocusListener = new OnFocusChangeListener() {
         @Override
         public void onFocusChange(View v, boolean hasFocus) {
-            if(hasFocus) {
+            if (hasFocus) {
                 mListener.onExpirationEntry();
             }
         }
@@ -238,6 +240,17 @@ public class ExpirationEditText extends EditText {
 			}
 			return super.sendKeyEvent(event);
 		}
+
+        @Override
+        public boolean performEditorAction(int editorAction) {
+            boolean shouldConsume = false;
+            switch (editorAction) {
+                case EditorInfo.IME_ACTION_DONE:
+                    shouldConsume = true;
+                    mListener.onCVVEntry();
+            }
+            return shouldConsume ? true : super.performEditorAction(editorAction);
+        }
 
         private void handleDelete() {
             if (getSelectionEnd() == 0) {

--- a/library/src/main/java/com/paymentkit/views/PostCodeEditText.java
+++ b/library/src/main/java/com/paymentkit/views/PostCodeEditText.java
@@ -136,6 +136,7 @@ public class PostCodeEditText extends EditText {
 	private TextWatcher mTextWatcher = new TextWatcher() {
 		@Override
 		public void afterTextChanged(Editable s) {
+            mListener.onPostCodeEdit();
 			if (s.length() == postCodeMaxLength) {
 				mListener.onPostCodeEntryComplete();
 			}

--- a/pKExample/src/main/AndroidManifest.xml
+++ b/pKExample/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name="com.brendan.pkexample.PKActivity"
-            android:label="@string/app_name" >
+            android:label="@string/app_name"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/pKExample/src/main/res/color/pk_action_button_text.xml
+++ b/pKExample/src/main/res/color/pk_action_button_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_enabled="false" android:color="@color/pk_DKGRAY" />
+    <item android:color="@color/pk_white" />
+</selector>

--- a/pKExample/src/main/res/layout/add_credit_card.xml
+++ b/pKExample/src/main/res/layout/add_credit_card.xml
@@ -38,7 +38,7 @@
                 android:layout_height="fill_parent"
                 android:background="@drawable/checkout_next_btn_bg"
                 android:text="Save"
-                android:textColor="@color/pk_white"
+                android:textColor="@color/pk_action_button_text"
                 android:textSize="17sp"
                 android:textStyle="bold" />
         </LinearLayout>
@@ -74,5 +74,16 @@
         android:layout_marginTop="10dp"
         android:text="Require Zip Code"
         android:checked="true" />
+
+    <TextView
+        android:id="@+id/valid_message"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginBottom="16dp"
+        android:text="Card data is invalid"
+        android:textStyle="italic"
+        android:textSize="16sp"/>
 
 </RelativeLayout>


### PR DESCRIPTION
Broaden the idea of FieldHolder's OnCardValidListener to send a valid/invalid
event whenever the data set's overall valid state changes. That is, if the user
edits a field to make it no longer valid, fire an invalid event - and then don't
send another event until the data becomes valid.
- Add unit tests for the validation event propagation.
- Update example app to prevent tapping the "Save" button if the data's not valid
  (and display when validation events happen).

Reviewers @cgould @galeng 

> For OpenTable use, this will support us disabling our "Next >" button whenever
> the data in the manual credit card entry form is not valid.
