### PR TITLE
Add Amex CVV Icon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.2
+version=1.0.3


### PR DESCRIPTION
Amex CVV is on the front of the card so use an card back image specific to Amex.
- Note: The hdpi, mdpi, ldpi images need to be tweaked a little when the PSD is
scaled down to get the red circle to not clip and the CVV number stroke style not
too big.
- Bumped version to 1.0.3