### PR TITLE
Add Amex CVV Icon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.2
+version=1.0.3

--- a/library/src/main/java/com/paymentkit/views/CardNumEditText.java
+++ b/library/src/main/java/com/paymentkit/views/CardNumEditText.java
@@ -11,6 +11,7 @@ import android.view.inputmethod.InputConnection;
 import android.view.inputmethod.InputConnectionWrapper;
 import android.widget.EditText;
 
+import com.paymentkit.CardType;
 import com.paymentkit.ValidateCreditCard;
 import com.paymentkit.util.ViewUtils;
 import com.paymentkit.views.FieldHolder.CardEntryListener;
@@ -52,6 +53,16 @@ public class CardNumEditText extends EditText {
 		setFilters(filters);
 	}
 
+	public void setMaxCardLength(CardType cardType) {
+		if (cardType == CardType.AMERICAN_EXPRESS) {
+			setMaxCardLength(FieldHolder.AMEX_CARD_LENGTH);
+		} else if (cardType == CardType.DINERS_CLUB) {
+			setMaxCardLength(FieldHolder.DINERS_CARD_LENGTH);
+		} else {
+			setMaxCardLength(FieldHolder.NON_AMEX_CARD_LENGTH);
+		}
+	}
+
     public String getLast4Digits() {
         String text = getText().toString().replaceAll("\\s", "");
         return text.substring(text.length() - 4, text.length());
@@ -67,13 +78,15 @@ public class CardNumEditText extends EditText {
             // Remove our selves while we edit this text.
             removeTextChangedListener(this);
 
+			CardType cardType = ValidateCreditCard.getCardType(s.toString());
+			setMaxCardLength(cardType);
+
             int oldSelectionPosition = getSelectionEnd();
             boolean removedTwoFromEnd = formatText(s);
             fixSelectionPosition(s, oldSelectionPosition, removedTwoFromEnd);
 
-
             // Notify listener
-            mCardEntryListener.onEdit();
+			mCardEntryListener.onEdit();
             if (isCardNumberInputComplete()) {
                 mCardEntryListener.onCardNumberInputComplete();
             }


### PR DESCRIPTION
Amex CVV is on the front of the card so use an card back image specific to Amex.
- Note: The hdpi, mdpi, ldpi images need to be tweaked a little when the PSD is
scaled down to get the red circle to not clip and the CVV number stroke style not
too big.

Bug Fix: Card Number Edit Must Set Correct Max Length Before Formatting

CardNumEditText needs to set the correct max length for its card type before it
calls formatText() (and isCardNumberInputComplete()) otherwise comparing format-
ted string length to the max length will be incorrect, primarily for AMEX and
Diner's Club.