### PR TITLE
[CYL-2598] Updated card entry form

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
            > NOT_FOUND_ERR: An attempt is made to reference a node in a context where it does not exist.
 
          */
-        classpath 'com.android.tools.build:gradle:0.13.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
         classpath 'com.github.dcendents:android-maven-plugin:1.0'
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=1.0.5
+version=1.0.6

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 16 13:44:52 PDT 2014
+#Thu Apr 07 12:02:27 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.13-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,14 +13,13 @@ android {
     buildToolsVersion "19.1.0"
 
     defaultConfig {
-        applicationId "com.paymentkit"
         minSdkVersion 8
         targetSdkVersion 19
     }
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
@@ -29,7 +28,7 @@ android {
 // Generate pom, ivy.xml
 // Note: We need the patched maven plugin since in the Android plugin, 'install' task is overridden
 // by 'installDebugTest', see: https://github.com/dcendents/android-maven-plugin
-apply plugin: 'android-maven'
+apply plugin: 'maven'
 // Basename of the AAR file (instead of 'library')
 archivesBaseName = 'paymentkit-android'
 uploadArchives {

--- a/library/src/main/java/com/paymentkit/views/CVVEditText.java
+++ b/library/src/main/java/com/paymentkit/views/CVVEditText.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.text.Editable;
 import android.text.InputFilter;
 import android.text.TextWatcher;
+import android.text.method.PasswordTransformationMethod;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.View;
@@ -22,6 +23,7 @@ public class CVVEditText extends EditText {
     public static final int CCV_AMEX_LENGTH = 4;
     private int cvvMaxLength = CCV_LENGTH;
 	
+	@SuppressWarnings("unused")
 	private static final String TAG = CVVEditText.class.getSimpleName();
 	
 	private CardEntryListener mListener;
@@ -39,6 +41,7 @@ public class CVVEditText extends EditText {
 	}
 	
 	private void setup() {
+		setTransformationMethod(PasswordTransformationMethod.getInstance());
 		addTextChangedListener(mTextWatcher);
 		setOnFocusChangeListener(mFocusListener);
 	}
@@ -104,7 +107,7 @@ public class CVVEditText extends EditText {
                         mListener.onCVVEntryComplete(); break;
                 }
             }
-			return shouldConsume ? true : super.sendKeyEvent(event);
+			return shouldConsume || super.sendKeyEvent(event);
 		}
 
         @Override
@@ -115,7 +118,7 @@ public class CVVEditText extends EditText {
                     shouldConsume = true;
                     mListener.onCVVEntryComplete();
             }
-            return shouldConsume ? true : super.performEditorAction(editorAction);
+            return shouldConsume || super.performEditorAction(editorAction);
         }
 
         @Override

--- a/library/src/main/java/com/paymentkit/views/PostCodeEditText.java
+++ b/library/src/main/java/com/paymentkit/views/PostCodeEditText.java
@@ -3,6 +3,7 @@ package com.paymentkit.views;
 import android.content.Context;
 import android.text.Editable;
 import android.text.InputFilter;
+import android.text.InputType;
 import android.text.TextWatcher;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
@@ -18,9 +19,10 @@ import com.paymentkit.views.FieldHolder.CardEntryListener;
 
 public class PostCodeEditText extends EditText {
 
-    public static final int US_POST_CODE_LENGTH = 5;
-    private int postCodeMaxLength = US_POST_CODE_LENGTH;
+    public static final int MAX_POSTAL_CODE_LENGTH = 10;
+    private int postCodeMaxLength;
 
+	@SuppressWarnings("unused")
 	private static final String TAG = PostCodeEditText.class.getSimpleName();
 
 	private CardEntryListener mListener;
@@ -40,10 +42,13 @@ public class PostCodeEditText extends EditText {
 	private void setup() {
 		addTextChangedListener(mTextWatcher);
 		setOnFocusChangeListener(mFocusListener);
+		setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS);
+		setFilters(new InputFilter[]{new InputFilter.AllCaps()});
+		setPostCodeMaxLength(MAX_POSTAL_CODE_LENGTH);
 	}
 
     public boolean isValid() {
-        return postCodeMaxLength == getText().toString().length();
+        return postCodeMaxLength >= getText().toString().length();
     }
 	
 	public void setCardEntryListener(CardEntryListener listener) {
@@ -103,7 +108,7 @@ public class PostCodeEditText extends EditText {
                         mListener.onPostCodeEntryComplete(); break;
                 }
             }
-			return shouldConsume ? true : super.sendKeyEvent(event);
+			return shouldConsume || super.sendKeyEvent(event);
 		}
 
         @Override
@@ -113,7 +118,7 @@ public class PostCodeEditText extends EditText {
                 case EditorInfo.IME_ACTION_DONE:
 					shouldConsume = mListener.onPostCodeEntryComplete();
             }
-            return shouldConsume ? true : super.performEditorAction(editorAction);
+            return shouldConsume || super.performEditorAction(editorAction);
         }
 
         @Override

--- a/library/src/main/java/com/paymentkit/views/PostCodeEditText.java
+++ b/library/src/main/java/com/paymentkit/views/PostCodeEditText.java
@@ -43,7 +43,6 @@ public class PostCodeEditText extends EditText {
 		addTextChangedListener(mTextWatcher);
 		setOnFocusChangeListener(mFocusListener);
 		setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_CAP_CHARACTERS);
-		setFilters(new InputFilter[]{new InputFilter.AllCaps()});
 		setPostCodeMaxLength(MAX_POSTAL_CODE_LENGTH);
 	}
 
@@ -57,10 +56,9 @@ public class PostCodeEditText extends EditText {
 
     public void setPostCodeMaxLength(int val) {
         postCodeMaxLength = val;
-        InputFilter[] filters = new InputFilter[1];
-        filters[0] = new InputFilter.LengthFilter(val);
-        setFilters(filters);
-    }
+		setFilters(new InputFilter[]{new InputFilter.AllCaps(),
+				new InputFilter.LengthFilter(val)});
+	}
 	
 	private OnFocusChangeListener mFocusListener = new OnFocusChangeListener() {
 		@Override

--- a/library/src/main/res/layout/pk_field_holder.xml
+++ b/library/src/main/res/layout/pk_field_holder.xml
@@ -75,7 +75,9 @@
         <com.paymentkit.views.PostCodeEditText
             android:id="@+id/post_code"
             style="@style/pk_CheckoutAddCardField"
-            android:layout_width="50dp"
+			android:minWidth="50dp"
+			android:maxWidth="120dp"
+            android:layout_width="wrap_content"
             android:layout_height="50dp"
             android:layout_gravity="center"
             android:contentDescription="Postal Code Field"
@@ -83,8 +85,7 @@
             android:imeOptions="actionDone|flagNoExtractUi"
             android:maxLength="5"
             android:nextFocusRight="@null"
-            android:visibility="gone"
-            tools:visibility="visible" />
+            android:visibility="visible"/>
 
     </LinearLayout>
 

--- a/pKExample/build.gradle
+++ b/pKExample/build.gradle
@@ -12,7 +12,7 @@ android {
 
     buildTypes {
         release {
-            runProguard false
+            minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
@@ -26,7 +26,7 @@ dependencies {
 // Generate pom, ivy.xml
 // Note: We need the patched maven plugin since in the Android plugin, 'install' task is overridden
 // by 'installDebugTest', see: https://github.com/dcendents/android-maven-plugin
-apply plugin: 'android-maven'
+apply plugin: 'maven'
 //2014-10-22 7:24PM - Maybe I shouldn't bother changing archivesBaseName and live with pKExample
 // Artifact/repository setup
 archivesBaseName = 'paymentkit-android-example'

--- a/pKExample/build.gradle
+++ b/pKExample/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "20.0.0"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         applicationId "com.brendan.pkexample"
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile project(':library')
-    compile 'com.android.support:support-v4:20.+'
+    compile 'com.android.support:support-v4:23.4.0'
 }
 
 // Generate pom, ivy.xml


### PR DESCRIPTION
Now it is set with the default behavior we use in the app code (password-like cvv, required postal code) as well as supporting international postal codes.
Reviewers: @galeng @bpenrod 
